### PR TITLE
feat: auto-detect owner from current repo and add interactive project picker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+BIN          := gh-kanban
+PKG          := ./cmd/kanban
+EXT_NAME     := gh-kanban
+EXT_DIR      := $(HOME)/.local/share/gh/extensions/$(EXT_NAME)
+
+.PHONY: build install uninstall reinstall run test vet tidy clean
+
+build:
+	go build -o $(BIN) $(PKG)
+
+install: build
+	mkdir -p $(EXT_DIR)
+	cp $(BIN) $(EXT_DIR)/$(EXT_NAME)
+	@echo "installed to $(EXT_DIR)/$(EXT_NAME)"
+	@echo "run: gh kanban"
+
+uninstall:
+	rm -rf $(EXT_DIR)
+	@echo "removed $(EXT_DIR)"
+
+reinstall: uninstall install
+
+run:
+	go run $(PKG)
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -f $(BIN)

--- a/internal/cli/picker.go
+++ b/internal/cli/picker.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/shuntaka9576/kanban/internal/gh"
+)
+
+type pickerModel struct {
+	projects []gh.ProjectSummary
+	cursor   int
+	selected *gh.ProjectSummary
+}
+
+func (m pickerModel) Init() tea.Cmd { return nil }
+
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch keyMsg.String() {
+	case "ctrl+c", "q", "esc":
+		return m, tea.Quit
+	case "j", "down":
+		if m.cursor < len(m.projects)-1 {
+			m.cursor++
+		}
+	case "k", "up":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "enter":
+		p := m.projects[m.cursor]
+		m.selected = &p
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m pickerModel) View() string {
+	var b strings.Builder
+	b.WriteString("Select a project (j/k or ↑/↓, enter to confirm, q to cancel)\n\n")
+	for i, p := range m.projects {
+		prefix := "  "
+		if i == m.cursor {
+			prefix = "▶ "
+		}
+		fmt.Fprintf(&b, "%s#%d  %s\n", prefix, p.Number, p.Title)
+	}
+	return b.String()
+}
+
+func pickProject(projects []gh.ProjectSummary) (*gh.ProjectSummary, error) {
+	final, err := tea.NewProgram(pickerModel{projects: projects}).Run()
+	if err != nil {
+		return nil, err
+	}
+	return final.(pickerModel).selected, nil
+}

--- a/internal/cli/view.go
+++ b/internal/cli/view.go
@@ -17,17 +17,23 @@ type ViewCmd struct {
 }
 
 func (c *ViewCmd) Run() error {
-	if c.Project == "" && c.Number == 0 {
-		return errors.New("specify --project/-p TITLE or --number/-N N")
-	}
 	if c.Project != "" && c.Number != 0 {
 		return errors.New("--project and --number are mutually exclusive")
 	}
 
-	client, err := gh.NewClient(gh.InitParams{
+	params := gh.InitParams{
 		UserLogin: c.User,
 		OrgLogin:  c.Org,
-	})
+	}
+	if params.UserLogin == "" && params.OrgLogin == "" {
+		detected, err := gh.DetectOwnerFromCurrentRepo()
+		if err != nil {
+			return fmt.Errorf("could not auto-detect owner from current repository (%w); specify --user/-u or --org/-o", err)
+		}
+		params = detected
+	}
+
+	client, err := gh.NewClient(params)
 	if err != nil {
 		if errors.Is(err, gh.ErrInvalidClientType) {
 			return errors.New("specify exactly one of --user/-u or --org/-o")
@@ -39,6 +45,30 @@ func (c *ViewCmd) Run() error {
 		Title:  c.Project,
 		Number: c.Number,
 	}
+
+	if spec.Title == "" && spec.Number == 0 {
+		projects, err := client.ListProjects()
+		if err != nil {
+			return fmt.Errorf("list projects: %w", err)
+		}
+		switch len(projects) {
+		case 0:
+			fmt.Printf("No projects found for %s.\n", client.Login)
+			return nil
+		case 1:
+			spec.Number = projects[0].Number
+		default:
+			sel, err := pickProject(projects)
+			if err != nil {
+				return err
+			}
+			if sel == nil {
+				return nil
+			}
+			spec.Number = sel.Number
+		}
+	}
+
 	label := specLabel(spec)
 
 	model := tui.New(client, spec, label)

--- a/internal/gh/detect.go
+++ b/internal/gh/detect.go
@@ -1,0 +1,44 @@
+package gh
+
+import (
+	"fmt"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/cli/go-gh/v2/pkg/repository"
+)
+
+func DetectOwnerFromCurrentRepo() (InitParams, error) {
+	repo, err := repository.Current()
+	if err != nil {
+		return InitParams{}, fmt.Errorf("detect current repository: %w", err)
+	}
+
+	gql, err := api.DefaultGraphQLClient()
+	if err != nil {
+		return InitParams{}, fmt.Errorf("graphql client: %w", err)
+	}
+
+	const q = `query($login: String!) {
+	  repositoryOwner(login: $login) { __typename }
+	}`
+	var resp struct {
+		RepositoryOwner *struct {
+			Typename string `json:"__typename"`
+		} `json:"repositoryOwner"`
+	}
+	if err := gql.Do(q, map[string]any{"login": repo.Owner}, &resp); err != nil {
+		return InitParams{}, fmt.Errorf("resolve owner type for %q: %w", repo.Owner, err)
+	}
+	if resp.RepositoryOwner == nil {
+		return InitParams{}, fmt.Errorf("owner %q not found", repo.Owner)
+	}
+
+	switch resp.RepositoryOwner.Typename {
+	case "Organization":
+		return InitParams{OrgLogin: repo.Owner}, nil
+	case "User":
+		return InitParams{UserLogin: repo.Owner}, nil
+	default:
+		return InitParams{}, fmt.Errorf("unsupported owner type %q for %q", resp.RepositoryOwner.Typename, repo.Owner)
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-detect the GitHub owner from the current git remote so `gh kanban` works without `--user`/`--org` inside any repository.
- When neither `--project` nor `--number` is given, fetch the owner's projectsV2 and route on count: `0` exits with a message, `1` opens directly, `n` shows an interactive Bubble Tea picker.
- Add a `Makefile` with `install`/`uninstall`/`reinstall` targets that bypass `gh extension install .` so local development works even though the working tree is named `kanban` (the repo was renamed to `gh-kanban`).

## Changes

- `internal/gh/detect.go` (new): `DetectOwnerFromCurrentRepo` calls `repository.Current()` and resolves `User` vs `Organization` via a `repositoryOwner.__typename` GraphQL lookup, returning a populated `InitParams`.
- `internal/cli/view.go`: drop the early "specify --project/--number" error; auto-detect the owner when both flags are empty, then call `client.ListProjects()` and dispatch (0 = exit cleanly, 1 = open, n = picker). `NewClient` and `InitParams` are unchanged.
- `internal/cli/picker.go` (new): minimal Bubble Tea selection model (`j/k`, `↑/↓`, `enter`, `q`/`esc`/`Ctrl-C`) using only the existing dependency — no new packages.
- `Makefile` (new): `make install` builds and copies the binary into `~/.local/share/gh/extensions/gh-kanban/gh-kanban`, plus `uninstall`/`reinstall`/`run`/`test`/`vet`/`tidy`/`clean`.

